### PR TITLE
Reomve node deps for browser compatibility

### DIFF
--- a/src/zodotenv.ts
+++ b/src/zodotenv.ts
@@ -1,4 +1,3 @@
-import assert from 'node:assert';
 import { ZodType } from 'zod';
 import type {
   EnvOptions,
@@ -8,6 +7,12 @@ import type {
   PathSplit,
   ZodotenvConfig,
 } from './types';
+
+function assert(condition: boolean, error?: Error): asserts condition {
+  if (!condition) {
+    throw error || new Error('Assertion failed');
+  }
+}
 
 export class ZodotenvError extends Error {
   constructor(message: string, cause?: Error) {


### PR DESCRIPTION
Replaced `node:assert` with a custom implementation because I was getting this error in the browser console: 

```
Uncaught (in promise) TypeError: (0 , import_node_assert.default) is not a function
    at zodotenv (zodotenv.js?v=1e3244e6:55:34)
    at config.ts:4:16
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Replaced the use of a built-in assertion utility with a custom assertion function for internal validation and error handling. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->