### PR TITLE
feat: adding support for zod 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ deno add npm:zodotenv
 
 ### Define your configuration
 ```ts
+// Zod 3, Zod 4 and Zod 4 Mini schemas are all supported
 import { z } from 'zod';
 import { zodotenv } from 'zodotenv';
 
@@ -41,8 +42,7 @@ const config = zodotenv({
 });
 ```
 
-> [!CAUTION]
-> If the environment variable doesn’t match the Zod schema, zodotenv will throw an error. Simple as that.
+⚠️ _If the environment variable doesn’t match the Zod schema, zodotenv will throw an error. Simple as that._
 
 
 ### Grab your values with `config(...)`
@@ -99,11 +99,14 @@ console.log(JSON.stringify(config, null, 2));
 
 Check out [Zod schemas](https://zod.dev/) if you haven't already!
 
-Since all environment variables are strings, you might need to use `.coerce` / `.transform()` / `.preprocess()` to convert them to the type you need:
+Since all environment variables are strings, you might need to use `.coerce` / `.transform()` / `.preprocess()` / `.stringbool()` to convert them to the type you need:
 
 ```ts
 // Boolean, e.g. `HTTP2=true`
 z.string().transform((s) => s === 'true')
+
+// Boolean from a "boolish" string when using Zod v4, e.g. `HTTP2=enabled`
+z.stringbool();
 
 // Number, e.g. `PORT=3000`
 z.coerce.number()

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,10 @@
         "pkgroll": "^2.5.1",
         "tsx": "^4.19.2",
         "typescript": "^5.6.3",
-        "zod": "^3.23.8"
+        "zod": "^3.25.0"
       },
       "peerDependencies": {
-        "zod": "3.x"
+        "zod": "^3.25.0"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -1881,11 +1881,10 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "version": "3.25.51",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.51.tgz",
+      "integrity": "sha512-TQSnBldh+XSGL+opiSIq0575wvDPqu09AqWe1F7JhUMKY+M91/aGlK4MhpVNO7MgYfHcVCB1ffwAUTJzllKJqg==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint:fix": "biome check . --write"
   },
   "peerDependencies": {
-    "zod": "3.x"
+    "zod": "^3.25.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
@@ -40,6 +40,6 @@
     "pkgroll": "^2.5.1",
     "tsx": "^4.19.2",
     "typescript": "^5.6.3",
-    "zod": "^3.23.8"
+    "zod": "^3.25.0"
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,13 @@
-import type { z } from 'zod';
+import type { ZodTypeAny as Zod3Type, infer as z3Infer } from 'zod/v3';
+import type { $ZodType as Zod4Type, infer as z4Infer } from 'zod/v4/core';
+
+export type ZodType = Zod3Type | Zod4Type;
 
 export interface EnvOptions {
   secret?: boolean;
 }
 
-export type EnvWithZodType = [string, z.ZodType, EnvOptions?];
+export type EnvWithZodType = [string, ZodType, EnvOptions?];
 
 export interface ZodotenvConfig {
   [name: string]: ZodotenvConfig | EnvWithZodType;
@@ -25,11 +28,13 @@ export type ObjectPathName<T, Prefix = '', Depth extends number = 5> = {
       : ObjectPathName<T[Key], `${string & Prefix}${string & Key}.`, Depths[Depth]>;
 }[keyof T];
 
+type zInfer<T> = T extends Zod3Type ? z3Infer<T> : z4Infer<T>;
+
 export type ObjectPathType<
   T,
   PathParts extends [keyof T, ...string[]],
 > = T[PathParts[0]] extends EnvWithZodType
-  ? z.infer<T[PathParts[0]][1]>
+  ? zInfer<T[PathParts[0]][1]>
   : ObjectPathType<
       T[PathParts[0]],
       PathParts extends [infer _First, ...infer Rest]

--- a/src/zodotenv.spec.ts
+++ b/src/zodotenv.spec.ts
@@ -68,12 +68,6 @@ describe('zodotenv', () => {
   });
 
   describe('Accessors', () => {
-    const originalEnv = structuredClone(process.env);
-
-    afterEach(() => {
-      process.env = originalEnv;
-    });
-
     it('returns both root and nested configs', () => {
       process.env.PORT = '3000';
       process.env.HTTP2 = 'true';

--- a/src/zodotenv.spec.ts
+++ b/src/zodotenv.spec.ts
@@ -1,10 +1,22 @@
 import assert from 'node:assert/strict';
-import { afterEach, describe, it } from 'node:test';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 import z from 'zod';
+import { z as z4 } from 'zod/v4';
+import { z as z4m } from 'zod/v4-mini';
 import type { ZodotenvConfig } from './types';
 import { zodotenv } from './zodotenv';
 
 describe('zodotenv', () => {
+  const originalEnv = structuredClone(process.env);
+
+  beforeEach(() => {
+    process.env = {};
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
   describe('Invalid configuration', () => {
     it('throws when the parameter is not an object', () => {
       assert.throws(() => zodotenv(1 as unknown as ZodotenvConfig), {
@@ -105,12 +117,6 @@ describe('zodotenv', () => {
   });
 
   describe('Serialisation', () => {
-    const originalEnv = structuredClone(process.env);
-
-    afterEach(() => {
-      process.env = originalEnv;
-    });
-
     it('serialises the entire configuration object to JSON', () => {
       process.env.PORT = '3000';
       process.env.HTTP2 = 'false';
@@ -190,6 +196,39 @@ describe('zodotenv', () => {
       };
 
       assert.deepEqual(JSON.parse(JSON.stringify(config)), expectedConfig);
+    });
+  });
+
+  describe('Zod 4 compatibility', () => {
+    it('works with Zod 4 schemas', () => {
+      process.env.NAME = 'my-app';
+      process.env.PORT = '3000';
+      process.env.HTTP2 = 'enabled';
+
+      const config = zodotenv({
+        name: ['NAME', z4.string().default('my-default-app')],
+        port: ['PORT', z4.coerce.number()],
+        http2: ['HTTP2', z4.stringbool()],
+      });
+
+      assert.equal(config('name'), 'my-app');
+      assert.equal(config('port'), 3000);
+      assert.equal(config('http2'), true);
+    });
+
+    it('works with Zod 4 Mini schemas', () => {
+      process.env.PORT = '3000';
+      process.env.HTTP2 = 'enabled';
+
+      const config = zodotenv({
+        name: ['NAME', z4m._default(z4m.string(), 'my-default-app')],
+        port: ['PORT', z4m.coerce.number()],
+        http2: ['HTTP2', z4m.stringbool()],
+      });
+
+      assert.equal(config('name'), 'my-default-app');
+      assert.equal(config('port'), 3000);
+      assert.equal(config('http2'), true);
     });
   });
 });

--- a/src/zodotenv.ts
+++ b/src/zodotenv.ts
@@ -1,11 +1,13 @@
 import assert from 'node:assert';
-import { ZodType } from 'zod';
+import { ZodType as Zod3Type } from 'zod';
+import { $ZodType as Zod4Type, safeParse } from 'zod/v4/core';
 import type {
   EnvOptions,
   EnvWithZodType,
   ObjectPathName,
   ObjectPathType,
   PathSplit,
+  ZodType,
   ZodotenvConfig,
 } from './types';
 
@@ -17,6 +19,9 @@ export class ZodotenvError extends Error {
   }
 }
 
+// https://zod.dev/library-authors?id=how-to-support-zod-3-and-zod-4-simultaneously
+const isZod4Schemma = (schema: ZodType): schema is Zod4Type => '_zod' in schema;
+
 const walk = (map: Map<string, unknown>, entry: ZodotenvConfig | EnvWithZodType, prefix = '') => {
   if (Array.isArray(entry)) {
     const [envName, schema, options] = entry;
@@ -25,9 +30,14 @@ const walk = (map: Map<string, unknown>, entry: ZodotenvConfig | EnvWithZodType,
       typeof envName === 'string' && envName.length > 0,
       new ZodotenvError(`Missing environment variable name for "${prefix}"`),
     );
-    assert(schema instanceof ZodType, new ZodotenvError('The provided schema is not a Zod type'));
+    assert(
+      schema instanceof Zod3Type || schema instanceof Zod4Type,
+      new ZodotenvError('The provided schema is not a Zod type'),
+    );
 
-    const { data, error } = schema.safeParse(process.env[envName]);
+    const { data, error } = isZod4Schemma(schema)
+      ? safeParse(schema, process.env[envName])
+      : schema.safeParse(process.env[envName]);
 
     if (error) {
       throw new ZodotenvError(

--- a/src/zodotenv.ts
+++ b/src/zodotenv.ts
@@ -20,7 +20,7 @@ export class ZodotenvError extends Error {
 }
 
 // https://zod.dev/library-authors?id=how-to-support-zod-3-and-zod-4-simultaneously
-const isZod4Schemma = (schema: ZodType): schema is Zod4Type => '_zod' in schema;
+const isZod4Schema = (schema: ZodType): schema is Zod4Type => '_zod' in schema;
 
 const walk = (map: Map<string, unknown>, entry: ZodotenvConfig | EnvWithZodType, prefix = '') => {
   if (Array.isArray(entry)) {
@@ -35,7 +35,7 @@ const walk = (map: Map<string, unknown>, entry: ZodotenvConfig | EnvWithZodType,
       new ZodotenvError('The provided schema is not a Zod type'),
     );
 
-    const { data, error } = isZod4Schemma(schema)
+    const { data, error } = isZod4Schema(schema)
       ? safeParse(schema, process.env[envName])
       : schema.safeParse(process.env[envName]);
 


### PR DESCRIPTION
Adding support for Zod 4 and Zod 4 Mini schemas according to https://zod.dev/library-authors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Zod 4 and Zod 4 Mini schemas in environment variable validation, alongside existing Zod 3 support.

- **Documentation**
  - Updated documentation to clarify support for Zod 3, Zod 4, and Zod 4 Mini.
  - Expanded guidance on boolean string conversion with `.stringbool()` and provided example usage.
  - Improved warning formatting for environment variable mismatches.

- **Tests**
  - Enhanced test coverage to verify compatibility with Zod 4 and Zod 4 Mini schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->