### PR TITLE
fix: avoid `infer` in generated types

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Validate and parse your environment variables like a responsible adult",
   "version": "1.3.0",
   "license": "MIT",
+  "keywords": ["zod", "env", "env var", "environment variables"],
   "author": {
     "name": "David Dios",
     "email": "dios.david@thedevcore.net"

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,8 @@
-import type { ZodTypeAny as Zod3Type, infer as z3Infer } from 'zod/v3';
-import type { $ZodType as Zod4Type, infer as z4Infer } from 'zod/v4/core';
+import type * as z3 from 'zod/v3';
+import type * as z4 from 'zod/v4/core';
+
+type Zod3Type = z3.ZodTypeAny;
+type Zod4Type = z4.$ZodType;
 
 export type ZodType = Zod3Type | Zod4Type;
 
@@ -28,7 +31,7 @@ export type ObjectPathName<T, Prefix = '', Depth extends number = 5> = {
       : ObjectPathName<T[Key], `${string & Prefix}${string & Key}.`, Depths[Depth]>;
 }[keyof T];
 
-type zInfer<T> = T extends Zod3Type ? z3Infer<T> : z4Infer<T>;
+type zInfer<T> = T extends Zod3Type ? z3.infer<T> : z4.infer<T>;
 
 export type ObjectPathType<
   T,

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,13 +31,13 @@ export type ObjectPathName<T, Prefix = '', Depth extends number = 5> = {
       : ObjectPathName<T[Key], `${string & Prefix}${string & Key}.`, Depths[Depth]>;
 }[keyof T];
 
-type zInfer<T> = T extends Zod3Type ? z3.infer<T> : z4.infer<T>;
+type ZInfer<T> = T extends Zod3Type ? z3.infer<T> : z4.infer<T>;
 
 export type ObjectPathType<
   T,
   PathParts extends [keyof T, ...string[]],
 > = T[PathParts[0]] extends EnvWithZodType
-  ? zInfer<T[PathParts[0]][1]>
+  ? ZInfer<T[PathParts[0]][1]>
   : ObjectPathType<
       T[PathParts[0]],
       PathParts extends [infer _First, ...infer Rest]


### PR DESCRIPTION
The generated types removed the renaming of the `infer` import to `z3Infer`, which messed up the types as `infer` is a reserved keyword in TS.

```ts
// from
import type { ZodTypeAny as Zod3Type, infer as z3Infer } from 'zod/v3';
// to
import { ZodTypeAny, infer } from 'zod/v3';
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced package metadata by adding relevant keywords.

- **Refactor**
  - Updated internal type import structure for improved consistency. No impact on end-user functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->