### PR TITLE
fix: include zod 4 in peer dependency range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "zod": "^3.25.0"
       },
       "peerDependencies": {
-        "zod": "^3.25.0"
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@biomejs/biome": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint:fix": "biome check . --write"
   },
   "peerDependencies": {
-    "zod": "^3.25.0"
+    "zod": "^3.25.0 || ^4.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",


### PR DESCRIPTION
- Widens the `zod` peer dependency from `^3.25.0` to `^3.25.0 || ^4.0.0`
- Consumers using Zod 4 were getting unmet peer dependency warnings despite Zod 4 being supported since v1.3.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated peer dependencies to support both Zod v3.25.0 and v4.0.0, providing greater flexibility for users with different Zod versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->